### PR TITLE
Fix for crash when importing /model/mover/animal/deer_run_jump_herd model from ats 1.32.

### DIFF
--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -145,7 +145,7 @@ bool Model::loadModel0x13(const uint8_t *const buffer, const size_t size)
 		currentBone->m_translation = bone->m_translation;
 		currentBone->m_scale = bone->m_scale;
 		currentBone->m_signOfDeterminantOfMatrix = bone->m_sign_of_determinant_of_matrix;
-		currentBone->m_parent = bone->m_parent;
+		currentBone->m_parent = (bone->m_parent != i) ? bone->m_parent : 0xff;
 
 		if (currentBone->m_name.empty())
 		{
@@ -371,7 +371,7 @@ bool Model::loadModel0x14(const uint8_t *const buffer, const size_t size)
 		currentBone->m_translation = bone->m_translation;
 		currentBone->m_scale = bone->m_scale;
 		currentBone->m_signOfDeterminantOfMatrix = bone->m_sign_of_determinant_of_matrix;
-		currentBone->m_parent = bone->m_parent;
+		currentBone->m_parent = (bone->m_parent != i) ? bone->m_parent : 0xff;
 
 		if (currentBone->m_name.empty())
 		{

--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -145,7 +145,7 @@ bool Model::loadModel0x13(const uint8_t *const buffer, const size_t size)
 		currentBone->m_translation = bone->m_translation;
 		currentBone->m_scale = bone->m_scale;
 		currentBone->m_signOfDeterminantOfMatrix = bone->m_sign_of_determinant_of_matrix;
-		currentBone->m_parent = (bone->m_parent != i) ? bone->m_parent : -1;
+		currentBone->m_parent = bone->m_parent;
 
 		if (currentBone->m_name.empty())
 		{
@@ -319,12 +319,12 @@ bool Model::loadModel0x13(const uint8_t *const buffer, const size_t size)
 				const auto animBind = *(const uint16_t *)(buffer + piece->m_anim_bind_offset + j * sizeof(uint16_t));
 				for (int k = 0; k < std::min(piece->m_bone_count, (i32)Vertex::BONE_COUNT); ++k)
 				{
-					vert->m_boneIndex[k] = *(const int8_t *)(buffer + piece->m_anim_bind_bones_offset + (animBind * piece->m_bone_count) + k);
+					vert->m_boneIndex[k] = *(const uint8_t *)(buffer + piece->m_anim_bind_bones_offset + (animBind * piece->m_bone_count) + k);
 					vert->m_boneWeight[k] = *(const uint8_t *)(buffer + piece->m_anim_bind_bones_weight_offset + (animBind * piece->m_bone_count) + k);
 				}
 				for (int k = std::min(piece->m_bone_count, (i32)Vertex::BONE_COUNT); k < Vertex::BONE_COUNT; ++k)
 				{
-					vert->m_boneIndex[k] = -1;
+					vert->m_boneIndex[k] = 0xff;
 					vert->m_boneWeight[k] = 0;
 				}
 			}
@@ -371,7 +371,7 @@ bool Model::loadModel0x14(const uint8_t *const buffer, const size_t size)
 		currentBone->m_translation = bone->m_translation;
 		currentBone->m_scale = bone->m_scale;
 		currentBone->m_signOfDeterminantOfMatrix = bone->m_sign_of_determinant_of_matrix;
-		currentBone->m_parent = (bone->m_parent != i) ? bone->m_parent : -1;
+		currentBone->m_parent = bone->m_parent;
 
 		if (currentBone->m_name.empty())
 		{
@@ -541,7 +541,7 @@ bool Model::loadModel0x14(const uint8_t *const buffer, const size_t size)
 				}
 				for (int bone = 4; bone < Vertex::BONE_COUNT; ++bone)
 				{
-					vert->m_boneIndex[bone] = -1;
+					vert->m_boneIndex[bone] = 0xff;
 					vert->m_boneWeight[bone] = 0;
 				}
 			}
@@ -1355,7 +1355,7 @@ bool Model::saveToPis(String exportPath) const
 				TAB TAB "             " FLT_FT "  " FLT_FT "  " FLT_FT "  " FLT_FT " )"		SEOL
 				TAB "  )" SEOL,
 					(int)i, m_bones[i].m_name.c_str(),
-					(m_bones[i].m_parent != -1 ? m_bones[m_bones[i].m_parent].m_name.c_str() : ""),
+					(m_bones[i].m_parent != 0xff ? m_bones[m_bones[i].m_parent].m_name.c_str() : ""),
 					flh(mat[0][0]), flh(mat[1][0]), flh(mat[2][0]), flh(mat[3][0]),
 					flh(mat[0][1]), flh(mat[1][1]), flh(mat[2][1]), flh(mat[3][1]),
 					flh(mat[0][2]), flh(mat[1][2]), flh(mat[2][2]), flh(mat[3][2]),

--- a/src/model/piece.h
+++ b/src/model/piece.h
@@ -35,7 +35,7 @@ struct Vertex
 	Float2 m_texcoords[TEXCOORD_COUNT];
 	Float4 m_color;
 	Float4 m_color2;
-	int8_t m_boneIndex[BONE_COUNT];
+	uint8_t m_boneIndex[BONE_COUNT];
 	uint8_t m_boneWeight[BONE_COUNT];
 };
 

--- a/src/structs/pmg_0x13.h
+++ b/src/structs/pmg_0x13.h
@@ -73,7 +73,7 @@ namespace prism
 			float3 m_translation;						// +168
 			float3 m_scale;								// +180
 			float m_sign_of_determinant_of_matrix;		// +192
-			i8 m_parent;								// +196
+			u8 m_parent;								// +196
 			u8 m_pad[3];								// +197
 		};	ENSURE_SIZE(pmg_bone_t, 200);
 

--- a/src/structs/pmg_0x14.h
+++ b/src/structs/pmg_0x14.h
@@ -70,7 +70,7 @@ namespace prism
 			float3 m_translation;						// +168
 			float3 m_scale;								// +180
 			float m_sign_of_determinant_of_matrix;		// +192
-			i8 m_parent;								// +196
+			u8 m_parent;								// +196
 			u8 m_pad[3];								// +197
 		};	ENSURE_SIZE(pmg_bone_data_t, 200);
 


### PR DESCRIPTION
The crash happened because this particular model has 177 bones (there are 5 deers running next to each other). When importing those bones, m_parent which was signed 1 byte, started to flip below 0 after reaching 127. Then these negative indexes were used when accessing m_bones Array. Changing the type of m_parent to unsigned 1 byte fixed the issue but then the mesh started to float around. To fix this I had to change the type of Vertex::m_boneIndex to unsigned 1 byte as well so that vertexes were assigned to proper bones. Now converter_pix is not crashing and the model and the animation works very well after importing to blender.