### PR TITLE
Fix to linear RGB to sRGB conversion for color values above 1.0

### DIFF
--- a/src/material/material.cpp
+++ b/src/material/material.cpp
@@ -400,11 +400,16 @@ void Material::convertAttribIfNeeded(Material::Attribute &attrib, const String &
 			maxVal = std::fmax(attrib.m_value[i], maxVal);
 	}
 
-	if (maxVal <= 1.0 || !convert)
+	if (!convert)
 		return;
 
 	for (size_t i = 0; i < values.size(); i++)
-		attrib.m_value[i] = lin2s(attrib.m_value[i] / maxVal) * maxVal;
+	{
+		if (maxVal <= 1.0)
+			attrib.m_value[i] = lin2s(attrib.m_value[i]);
+		else
+			attrib.m_value[i] = lin2s(attrib.m_value[i] / maxVal) * maxVal;
+	}
 }
 
 /* eof */

--- a/src/material/material.h
+++ b/src/material/material.h
@@ -78,6 +78,8 @@ public:
 
 	bool convertTextures(String exportPath) const;
 
+	static void convertAttribIfNeeded(Material::Attribute &attrib, const String &effect, const String &attribName, const Array<String> &values);
+
 private:
 	String m_effect;
 	Array<Texture> m_textures;
@@ -87,32 +89,5 @@ private:
 
 	friend Model;
 };
-
-static double convertAtribIfNeeded(String effect, String attrib, double value)
-{
-	/**
-	* @brief The ambient, diffuse, specular, tint, env_factor and water aux are converted from srgb to linear
-	*/
-
-	static const char *const attributesLinear[] = { "ambient", "diffuse", "specular", "tint", "env_factor" };
-
-	for (const auto &attribb : attributesLinear)
-	{
-		if (attrib == attribb)
-		{
-			return lin2s((float)value);
-		}
-	}
-
-	if (effect == "eut2.water")
-	{
-		if (attrib == "aux[1]" || attrib == "aux[2]")
-		{
-			return lin2s((float)value);
-		}
-	}
-
-	return value;
-}
 
 /* eof */

--- a/src/prerequisites.cpp
+++ b/src/prerequisites.cpp
@@ -24,15 +24,15 @@
 
 #include <cityhash/city.h>
 
-float s2lin(float x)
+double s2lin(double x)
 {
-	const float a = 0.055f;
+	const double a = 0.055f;
 	return ((x <= 0.04045f) ? (x * (1.f / 12.92f)) : (pow((x + a) * (1.f / (1.f + a)), 2.4f)));
 }
 
-float lin2s(float x)
+double lin2s(double x)
 {
-	const float a = 0.055f;
+	const double a = 0.055f;
 	return ((x <= 0.0031308f) ? (x * 12.92f) : ((1.f + a) * pow(x, 1.f / 2.4f) - a));
 }
 

--- a/src/prerequisites.h
+++ b/src/prerequisites.h
@@ -187,7 +187,7 @@ class ResourceLibrary;
  * @param[in] x The srgb value
  * @return @c The linear value
 */
-float s2lin(float x);
+double s2lin(double x);
 
 /**
  * @brief: Converts linear to srgb color space
@@ -195,7 +195,7 @@ float s2lin(float x);
  * @param[in] x The linear value
  * @return @c The srgb value
 */
-float lin2s(float x);
+double lin2s(double x);
 
 inline uint32_t flh(float x)
 {


### PR DESCRIPTION
According to 50keda's message here: https://forum.scssoft.com/viewtopic.php?p=1409264#p1409264 when converting linear RGB color values written in .mat files to sRGB values used in .pit files, converter_pix should first normalize all RGB components by dividing them by the highest value (if that value is above 1.0) so that the values are scaled to 0...1 range, then should perform the lin2s conversion and finally scale all values back by multiplying all sRGB components by the same highest value used at the beginning.
Currently when doing a conversion loop (.mat -> .pit -> .mat -> .pit -> ...) with converter_pix and scs conversion tools, color values above 1.0 are getting broken with each iteration so they finally get down to 1.0.
After implementing my fix I tested it and it looks that all RGB components are now correctly converted - you can see the test result here - https://forum.scssoft.com/viewtopic.php?p=1410835#p1410835

About the implementation: I refactored the static function convertAttribIfNeeded() so that it now accepts Material::Attribute reference (in/out) as the first parameter and I made the function a part of the Material class so that it can access the private member Material::Attribute::m_value. I also changed lin2s and s2lin to use double instead of float values so there is no need anymore to cast passed values to float.