### PR TITLE
Mat 147

### DIFF
--- a/src/Core.vcxproj
+++ b/src/Core.vcxproj
@@ -23,6 +23,7 @@
     <ClInclude Include="fs\zipfilesystem.h" />
     <ClInclude Include="fs\zipfs_file.h" />
     <ClInclude Include="material\material.h" />
+    <ClInclude Include="material\material_converter_147.h" />
     <ClInclude Include="math\aabox.h" />
     <ClInclude Include="math\matrix.h" />
     <ClInclude Include="math\quaternion.h" />
@@ -92,6 +93,9 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="material\material.cpp" />
+    <ClCompile Include="material\material_converter_147.cpp" />
+    <ClCompile Include="material\material_post_147.cpp" />
+    <ClCompile Include="material\material_pre_147.cpp" />
     <ClCompile Include="model\animation.cpp" />
     <ClCompile Include="model\collision.cpp" />
     <ClCompile Include="model\model.cpp" />
@@ -113,7 +117,7 @@
     <ProjectGuid>{7AF227E8-E1B1-4364-A66F-3752D1B23713}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>Core</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -126,7 +130,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>NotSet</CharacterSet>
   </PropertyGroup>

--- a/src/Core.vcxproj
+++ b/src/Core.vcxproj
@@ -117,7 +117,7 @@
     <ProjectGuid>{7AF227E8-E1B1-4364-A66F-3752D1B23713}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>Core</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -130,7 +130,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>NotSet</CharacterSet>
   </PropertyGroup>

--- a/src/cmd/_main.cpp
+++ b/src/cmd/_main.cpp
@@ -176,6 +176,10 @@ int main(int argc, char *argv[])
 			mode = SHOW_FILE;
 			parameter = &path;
 		}
+		else if (arg == "-matFormat147")
+		{
+			Material::s_outputMatFormat147Enabled = true;
+		}
 		else
 		{
 			optionalArgs.push_back(arg);

--- a/src/material/material.cpp
+++ b/src/material/material.cpp
@@ -153,54 +153,7 @@ bool Material::load(String filePath)
 
 	return true;
 }
-/*
-String Material::toDefinition(const String &prefix) const
-{
-	String result;
-	result += prefix + "Material {\n";
-	{
-		result += prefix + fmt::sprintf(TAB "Alias: \"%s\"\n", alias().c_str());
-		result += prefix + fmt::sprintf(TAB "Effect: \"%s\"\n", m_effect.c_str());
-		result += prefix + fmt::sprintf(TAB "Flags: %i\n", 0);
-		result += prefix + fmt::sprintf(TAB "AttributeCount: %i\n", (int32_t)m_attributes.size());
-		result += prefix + fmt::sprintf(TAB "TextureCount: %i\n", (int32_t)m_textures.size());
-		for (AttributesMap::const_iterator it = m_attributes.begin(); it != m_attributes.end(); ++it)
-		{
-			result += prefix + TAB + "Attribute {\n";
-			{
-				result += prefix + fmt::sprintf(TAB TAB "Format: %s" SEOL, it->second.getFormat());
-				result += prefix + fmt::sprintf(TAB TAB "Tag: \"%s\"" SEOL, it->second.m_name.c_str());
-				result += prefix + fmt::sprintf(TAB TAB "Value: ( ");
-				if (it->second.m_valueType == Attribute::FLOAT)
-				{
-					for (uint32_t j = 0; j < it->second.m_valueCount; ++j)
-					{
-						result += fmt::sprintf("%f ", it->second.m_value[j]);
-					}
-				}
-				else
-				{
-					result += "\"" + it->second.m_stringValue + "\" ";
-				}
-				result += ")" SEOL;
-			}
-			result += prefix + TAB + "}\n";
-		}
-		for (size_t i = 0; i < m_textures.size(); ++i)
-		{
-			const Texture *const tex = &m_textures[i];
-			result += prefix + TAB + "Texture {\n";
-			{
-				result += prefix + fmt::sprintf(TAB TAB "Tag: \"texture[%i]:%s\"\n", (int)i, tex->m_textureName.c_str());
-				result += prefix + fmt::sprintf(TAB TAB "Value: \"%s\"\n", String(tex->m_texture.c_str()).substr(0, tex->m_texture.length() - 5).c_str());
-			}
-			result += prefix + TAB + "}\n";
-		}
-	}
-	result += prefix + "}\n";
-	return result;
-}
-*/
+
 String Material::toDeclaration(const String &prefix) const
 {
 	String result;

--- a/src/material/material.cpp
+++ b/src/material/material.cpp
@@ -23,6 +23,7 @@
 #include <prerequisites.h>
 
 #include "material.h"
+#include "material_converter_147.h"
 
 #include <resource_lib.h>
 #include <structs/tobj.h>
@@ -65,74 +66,6 @@ String Material::Attribute::getFormat() const
 	}
 	return "UNKNOWN";
 }
-
-Material::AttributeConvert::AttributeConvert(String oldName, int valueCount, int startIndex)
-	: m_oldName(oldName)
-	, m_valueCount(valueCount)
-	, m_startIndex(startIndex)
-{
-}
-
-Material::AttributeConvertMap Material::m_convertMap = {
-	{ "additional_ambient", Material::AttributeConvert("add_ambient", 1, 0) },
-	{ "glass_tint_color", Material::AttributeConvert("tint", 3, 0) },
-	{ "glass_tint_opacity", Material::AttributeConvert("tint_opacity", 1, 0) },
-	{ "shadowmap_bias", Material::AttributeConvert("shadow_bias", 1, 0) },
-	{ "paintjob_base_color", Material::AttributeConvert("aux[8]", 3, 0) },
-	{ "specular_secondary", Material::AttributeConvert("aux[3]", 4, 0) },
-	{ "shininess_secondary", Material::AttributeConvert("aux[3]", 4, 3) },
-	{ "reflection_secondary", Material::AttributeConvert("reflection2", 1, 0) },
-	{ "lod_selector", Material::AttributeConvert("aux[1]", 1, 0) },
-	{ "shadow_offset", Material::AttributeConvert("aux[0]", 1, 0) },
-	{ "amod_decal_blending_factors", Material::AttributeConvert("amod_decal_blending_factors", 2, 0) }, //not present in materials until 1.47
-	{ "texgen_0_gen", Material::AttributeConvert("aux[0]", 2, 0) },
-	{ "texgen_0_rot", Material::AttributeConvert("texgen_0_rot", 1, 0) }, //not present in materials until 1.47
-	{ "texgen_1_gen", Material::AttributeConvert("aux[1]", 2, 0) },
-	{ "texgen_1_rot", Material::AttributeConvert("texgen_1_rot", 1, 0) }, //not present in materials until 1.47
-	{ "depth_bias", Material::AttributeConvert("aux[0]", 1, 0) },
-	{ "luminance_output", Material::AttributeConvert("aux[5]", 2, 0) },
-	{ "luminance_night", Material::AttributeConvert("aux[5]", 2, 1) },
-	{ "water_distances", Material::AttributeConvert("aux[0]", 3, 0) },
-	{ "water_near_color", Material::AttributeConvert("aux[1]", 3, 0) },
-	{ "water_horizon_color", Material::AttributeConvert("aux[2]", 3, 0) },
-	{ "water_layer_0_yaw", Material::AttributeConvert("aux[3]", 4, 0) },
-	{ "water_layer_0_speed", Material::AttributeConvert("aux[3]", 4, 1) },
-	{ "water_layer_0_scale", Material::AttributeConvert("aux[3]", 4, 2) },
-	{ "water_layer_1_yaw", Material::AttributeConvert("aux[4]", 4, 0) },
-	{ "water_layer_1_speed", Material::AttributeConvert("aux[4]", 4, 1) },
-	{ "water_layer_1_scale", Material::AttributeConvert("aux[4]", 4, 2) },
-	{ "water_mirror", Material::AttributeConvert("aux[5]", 1, 0) },
-	{ "animsheet_cfg_fps", Material::AttributeConvert("aux[0]", 3, 0) },
-	{ "animsheet_cfg_frames_row", Material::AttributeConvert("aux[0]", 3, 1) },
-	{ "animsheet_cfg_frames_total", Material::AttributeConvert("aux[0]", 3, 2) },
-	{ "animsheet_frame_width", Material::AttributeConvert("aux[1]", 2, 0) },
-	{ "animsheet_frame_height", Material::AttributeConvert("aux[1]", 2, 1) },
-	{ "detail_fadeout_from", Material::AttributeConvert("aux[5]", 4, 0) },
-	{ "detail_fadeout_range", Material::AttributeConvert("aux[5]", 4, 1) },
-	{ "detail_blend_bias", Material::AttributeConvert("aux[5]", 4, 2) },
-	{ "detail_uv_scale", Material::AttributeConvert("aux[5]", 4, 3) },
-	{ "animation_speed", Material::AttributeConvert("aux[0]", 1, 0) },
-	{ "showroom_r_color", Material::AttributeConvert("aux[0]", 1, 0) }, //was single float, since 1.47 is 3d vector
-	{ "showroom_speed", Material::AttributeConvert("aux[4]", 3, 0) },
-	{ "flake_uvscale", Material::AttributeConvert("aux[5]", 4, 0) },
-	{ "flake_shininess", Material::AttributeConvert("aux[5]", 4, 1) },
-	{ "flake_clearcoat_rolloff", Material::AttributeConvert("aux[5]", 4, 2) },
-	{ "flake_vratio", Material::AttributeConvert("aux[5]", 4, 3) },
-	{ "flake_color", Material::AttributeConvert("aux[6]", 4, 0) },
-	{ "flake_density", Material::AttributeConvert("aux[6]", 4, 3) },
-	{ "flip_color", Material::AttributeConvert("aux[7]", 4, 0) },
-	{ "flip_strength", Material::AttributeConvert("aux[7]", 4, 3) },
-	{ "mix00_diffuse_secondary", Material::AttributeConvert("mix00_diffuse_secondary", 3, 0) }, //not present in materials until 1.47
-	{ "mult_uvscale", Material::AttributeConvert("aux[5]", 4, 0) },
-	{ "mult_uvscale_secondary", Material::AttributeConvert("aux[5]", 4, 2) },
-	{ "sheet_frame_size_r", Material::AttributeConvert("aux[0]", 4, 0) },
-	{ "sheet_frame_size_g", Material::AttributeConvert("aux[0]", 4, 2) },
-	{ "sheet_frame_size_b", Material::AttributeConvert("aux[1]", 4, 0) },
-	{ "sheet_frame_size_a", Material::AttributeConvert("aux[1]", 4, 2) },
-	{ "paintjob_r_color", Material::AttributeConvert("aux[5]", 3, 0) },
-	{ "paintjob_g_color", Material::AttributeConvert("aux[6]", 3, 0) },
-	{ "paintjob_b_color", Material::AttributeConvert("aux[7]", 3, 0) }
-};
 
 void Material::destroy()
 {
@@ -205,153 +138,10 @@ bool Material::load(String filePath)
 
 	buffer = buffer.substr(brace_left + 1, brace_right - brace_left - 1);
 
-	std::stringstream ssbuffer(buffer);
-
-	while (std::getline(ssbuffer, buffer))
-	{
-		size_t middle = buffer.find(':');
-		if (middle == String::npos)
-		{
-			continue;
-		}
-
-		const String name = removeSpaces(buffer.substr(0, middle));
-		const String nameWithoutIndex = removeSpaces(name.substr(0, name.find('[')));
-		String value = removeSpaces(buffer.substr(middle + 1));
-
-		Array<String> values;
-
-		size_t braceLeft = value.find('{');
-		size_t quoteLeft = value.find('\"');
-
-		if (braceLeft != String::npos && name != "texture")
-		{
-			size_t braceRight = value.find('}');
-			if (braceRight == String::npos)
-			{
-				warning("material", m_filePath, "Unable to find closing brace!");
-				continue;
-			}
-			String valuesArray = value.substr(braceLeft + 1, braceRight - braceLeft - 1);
-			std::replace_if(valuesArray.begin(), valuesArray.end(), [](char ch)->bool { return ch == ','; }, ' ');
-
-			char valuesArray2[128] = { 0 }, tempValue[128] = { 0 };
-			strcpy(valuesArray2, valuesArray.c_str());
-			const char *valuesArrayptr = valuesArray2;
-			while (sscanf(valuesArrayptr, "%s", tempValue) != EOF)
-			{
-				values.push_back(tempValue);
-				valuesArrayptr += strlen(tempValue) + 1;
-			}
-		}
-		else if (braceLeft != String::npos && name == "texture")
-		{
-			/* handles the new format of texture attribute since 1.47
-			* texture : "texture_name" {
-			*	source : "texture_path"
-			* }
-			*/
-
-			String textureType = betweenQuotes(value);
-			if (textureType == "ERROR")
-			{
-				warning("material", m_filePath, "Unable to parse texture type!");
-				continue;
-			}
-			std::getline(ssbuffer, buffer); //assuming the "source" attribute is in the next line
-			middle = buffer.find(':');
-			if (removeSpaces(buffer.substr(0, middle)) != "source")
-			{
-				warning("material", m_filePath, "Unexpected texture attribute: " + removeSpaces(buffer.substr(0, middle)));
-				continue;
-			}
-			value = removeSpaces(buffer.substr(middle + 1));
-			quoteLeft = value.find('\"');
-			if (quoteLeft != String::npos)
-			{
-				value = betweenQuotes(value);
-			}
-
-			Texture newTexture;
-			newTexture.m_texture = value[0] == '/' ? value.c_str() : directory(m_filePath) + "/" + value.c_str();
-			newTexture.m_textureName = textureType;
-			m_textures.push_back(newTexture);
-
-			std::getline(ssbuffer, buffer); //read the closing brace
-			continue;
-		}
-		else if (quoteLeft != String::npos)
-		{
-			value = betweenQuotes(value);
-		}
-		else
-		{
-			values.push_back(value);
-		}
-
-		if ((nameWithoutIndex == "texture" || nameWithoutIndex == "texture_name") && name != nameWithoutIndex)
-		{
-			//handles the old format of texture attribute
-			auto textureProperty = [&]()->int {
-				int indexTexture = 0;
-				size_t indexBraceLeft = name.find('[');
-				size_t indexBraceRight = name.find(']');
-				if (indexBraceLeft != String::npos && indexBraceRight != String::npos)
-				{
-					indexTexture = atoi(name.substr(indexBraceLeft + 1, indexBraceRight - 1).c_str());
-				}
-				if (indexTexture >= (int)m_textures.size())
-				{
-					m_textures.resize(indexTexture + 1);
-				}
-				return indexTexture;
-			};
-
-			if (nameWithoutIndex == "texture_name")
-			{
-				m_textures[textureProperty()].m_textureName = value.c_str();
-			}
-			else if (nameWithoutIndex == "texture")
-			{
-				m_textures[textureProperty()].m_texture = value[0] == '/' ? value.c_str() : directory(m_filePath) + "/" + value.c_str();
-			}
-		}
-		else if (name != "queue_bias" && name != "texture")
-		{
-			AttributeConvertMap::iterator convertRule = m_convertMap.find(name);
-			bool needConversion = (convertRule != m_convertMap.end());
-			String nameAfterConversion;
-
-			if (needConversion)
-				nameAfterConversion = convertRule->second.m_oldName;
-			else
-				nameAfterConversion = name;
-
-			Attribute& attrib = m_attributes[nameAfterConversion];
-			attrib.m_name = nameAfterConversion;
-
-			if (values.size() > 0)
-			{
-				if (values.size() > 4)
-				{
-					warning("material", m_filePath, "Too many values in the attribute!");
-					continue;
-				}
-				attrib.m_valueType = Attribute::FLOAT;
-				if (needConversion)
-					attrib.m_valueCount = convertRule->second.m_valueCount;
-				else
-					attrib.m_valueCount = values.size();
-
-				convertAttribIfNeeded(attrib, effect, name, values, needConversion ? convertRule->second.m_startIndex : 0);
-			}
-			else
-			{
-				attrib.m_valueType = Attribute::STRING;
-				attrib.m_stringValue = value.c_str();
-			}
-		}
-	}
+	if (check_mat == "effect")
+		loadPost147Format(buffer);
+	else
+		loadPre147Format(buffer);
 
 	for (auto &tex : m_textures)
 	{
@@ -363,7 +153,7 @@ bool Material::load(String filePath)
 
 	return true;
 }
-
+/*
 String Material::toDefinition(const String &prefix) const
 {
 	String result;
@@ -410,7 +200,7 @@ String Material::toDefinition(const String &prefix) const
 	result += prefix + "}\n";
 	return result;
 }
-
+*/
 String Material::toDeclaration(const String &prefix) const
 {
 	String result;
@@ -421,40 +211,6 @@ String Material::toDeclaration(const String &prefix) const
 	}
 	result += prefix + "}\n";
 	return result;
-}
-
-Pix::Value Material::toPixDefinition() const
-{
-	Pix::Value root;
-	root["Alias"] = alias();
-	root["Effect"] = m_effect;
-	root["Flags"] = 0;
-	root["AttributeCount"] = m_attributes.size();
-	root["TextureCount"] = m_textures.size();
-
-	for (AttributesMap::const_iterator it = m_attributes.begin(); it != m_attributes.end(); ++it)
-	{
-		Pix::Value &attribute = root["Attribute"];
-		attribute["Format"] = Pix::Value::Enumeration(it->second.getFormat());
-		attribute["Tag"] = it->second.m_name;
-		if (it->second.m_valueType == Attribute::FLOAT)
-		{
-			attribute["Value"] = Pix::Value(it->second.m_value, it->second.m_valueCount);
-		}
-		else
-		{
-			attribute["Value"] = Pix::Value::Enumeration("( \"" + it->second.m_stringValue + "\" )");
-		}
-	}
-
-	for (size_t i = 0; i < m_textures.size(); ++i)
-	{
-		const Texture *const tex = &m_textures[i];
-		Pix::Value &texture = root["Texture"];
-		texture["Tag"] = fmt::sprintf("texture[%i]:%s", (int)i, tex->m_textureName);
-		texture["Value"] = tex->m_texture.substr(0, tex->m_texture.length() - 5); // -5 -> .tobj removing
-	}
-	return root;
 }
 
 Pix::Value Material::toPixDeclaration() const
@@ -487,45 +243,45 @@ bool Material::convertTextures(String exportPath) const
 	return true;
 }
 
-void Material::convertAttribIfNeeded(Material::Attribute &attrib, const String &effect, const String &attribName, const Array<String> &values, const int startIndex)
+void Material::setValues(Material::Attribute &attrib, const Array<String> &values, const int startIndex)
 {
 	/**
-	* @brief The ambient, diffuse, specular, tint, env_factor and water aux are converted from srgb to linear
+	* @brief Color values are converted from srgb to linear
 	*/
 
-	static const char *const attributesLinear[] = { "ambient", "diffuse", "specular", "tint", "env_factor" };
+	static const char *const attributesLinear[] = { "ambient", "diffuse", "specular", "glass_tint_color", "env_factor", 
+													"water_near_color", "water_horizon_color", "specular_secondary",
+													"paintjob_base_color", "flake_color", "flip_color",
+													"paintjob_r_color", "paintjob_g_color", "paintjob_b_color"};
 
 	double maxVal = 0;
 	bool convert = false;
 
 	for (const auto &attribb : attributesLinear)
 	{
-		if (attribName == attribb)
+		if (attrib.m_name == attribb)
 		{
 			convert = true;
 			break;
 		}
 	}
 
-	if (effect == "eut2.water" && (attribName == "aux[1]" || attribName == "aux[2]"))
-		convert = true;
-
-	for (size_t i = 0; i < values.size(); i++)
+	for (size_t i = 0; i < attrib.m_valueCount; i++)
 	{
-		attrib.m_value[startIndex+i] = atof(values[i].c_str());
+		attrib.m_value[i] = atof(values[startIndex+i].c_str());
 		if (convert)
-			maxVal = std::fmax(attrib.m_value[startIndex+i], maxVal);
+			maxVal = std::fmax(attrib.m_value[i], maxVal);
 	}
 
 	if (!convert)
 		return;
 
-	for (size_t i = 0; i < values.size(); i++)
+	for (size_t i = 0; i < attrib.m_valueCount; i++)
 	{
 		if (maxVal <= 1.0)
-			attrib.m_value[startIndex+i] = lin2s(attrib.m_value[startIndex+i]);
+			attrib.m_value[i] = lin2s(attrib.m_value[i]);
 		else
-			attrib.m_value[startIndex+i] = lin2s(attrib.m_value[startIndex+i] / maxVal) * maxVal;
+			attrib.m_value[i] = lin2s(attrib.m_value[i] / maxVal) * maxVal;
 	}
 }
 

--- a/src/material/material.cpp
+++ b/src/material/material.cpp
@@ -32,6 +32,8 @@
 #include <fs/file.h>
 #include <fs/uberfilesystem.h>
 
+bool Material::s_outputMatFormat147Enabled = false;
+
 Material::Attribute::Attribute()
 	: m_valueType(FLOAT)
 	, m_valueCount(0)
@@ -164,6 +166,18 @@ String Material::toDeclaration(const String &prefix) const
 	}
 	result += prefix + "}\n";
 	return result;
+}
+
+Pix::Value Material::toPixDefinition() const
+{
+	if (s_outputMatFormat147Enabled)
+	{
+		return toPixDefinitionPost147();
+	}
+	else
+	{
+		return toPixDefinitionPre147();
+	}
 }
 
 Pix::Value Material::toPixDeclaration() const

--- a/src/material/material.h
+++ b/src/material/material.h
@@ -55,6 +55,7 @@ public:
 
 	String toDeclaration(const String &prefix = "") const;
 
+	Pix::Value toPixDefinition() const;
 	Pix::Value toPixDefinitionPre147() const;
 	Pix::Value toPixDefinitionPost147() const;
 	Pix::Value toPixDeclaration() const;
@@ -73,6 +74,8 @@ public:
 	static void setValues(Material::Attribute &attrib, const Array<String> &values, const int startIndex = 0);
 
 	typedef Map<String, Attribute> AttributesMap; //changed to map since 1.47 to easily insert values to a single old attribute from multiple new attributes
+
+	static bool s_outputMatFormat147Enabled;
 
 private:
 	String m_effect;

--- a/src/material/material.h
+++ b/src/material/material.h
@@ -73,7 +73,7 @@ public:
 
 	static void setValues(Material::Attribute &attrib, const Array<String> &values, const int startIndex = 0);
 
-	typedef Map<String, Attribute> AttributesMap; //changed to map since 1.47 to easily insert values to a single old attribute from multiple new attributes
+	typedef Map<String, Attribute> AttributesMap;
 
 	static bool s_outputMatFormat147Enabled;
 

--- a/src/material/material.h
+++ b/src/material/material.h
@@ -73,7 +73,7 @@ public:
 
 	static void setValues(Material::Attribute &attrib, const Array<String> &values, const int startIndex = 0);
 
-	typedef Map<String, Attribute> AttributesMap;
+	using AttributesMap = Map<String, Attribute>;
 
 	static bool s_outputMatFormat147Enabled;
 

--- a/src/material/material.h
+++ b/src/material/material.h
@@ -50,6 +50,26 @@ public:
 		friend Material;
 	};
 
+	class AttributeConvert
+	{
+	public:
+		AttributeConvert(String oldName, int valueCount, int startIndex);
+	private:
+		String m_oldName;
+		uint32_t m_valueCount;
+		/* some new attributes map to a single old attribute
+		* example:
+		* detail_fadeout_from -> aux[5][0]
+		* detail_fadeout_range -> aux[5][1]
+		* detail_blend_bias -> aux[5][2]
+		* detail_uv_scale -> aux[5][3]
+		* that's why we need the startIndex to insert the value at specified offset
+		*/
+		uint32_t m_startIndex;
+
+		friend Material;
+	};
+
 public:
 	bool load(String filePath);
 	void destroy();
@@ -78,14 +98,19 @@ public:
 
 	bool convertTextures(String exportPath) const;
 
-	static void convertAttribIfNeeded(Material::Attribute &attrib, const String &effect, const String &attribName, const Array<String> &values);
+	static void convertAttribIfNeeded(Material::Attribute &attrib, const String &effect, const String &attribName, const Array<String> &values, const int startIndex = 0);
+
+	typedef Map<String, Attribute> AttributesMap; //changed to map since 1.47 to easily insert values to a single old attribute from multiple new attributes
+	typedef Map<String, AttributeConvert> AttributeConvertMap; //since 1.47 - map of new attribute names to old attribute names
 
 private:
 	String m_effect;
 	Array<Texture> m_textures;
-	Array<Attribute> m_attributes;
+	AttributesMap m_attributes;
 	String m_filePath;		// @example: /material/example.mat
 	String m_alias;
+
+	static AttributeConvertMap m_convertMap;
 
 	friend Model;
 };

--- a/src/material/material.h
+++ b/src/material/material.h
@@ -53,14 +53,6 @@ public:
 	void loadPost147Format(String &content);
 	void destroy();
 
-	/**
-	 * @brief Creates PIT definition
-	 *
-	 * @param[in] prefix The prefix for each line of generated definition
-	 * @return @c The definition of material
-	 */
-	//String toDefinition(const String &prefix = "") const;
-
 	String toDeclaration(const String &prefix = "") const;
 
 	Pix::Value toPixDefinitionPre147() const;

--- a/src/material/material.h
+++ b/src/material/material.h
@@ -40,14 +40,11 @@ public:
 		void clear();
 		String getFormat() const;
 
-	private:
 		String m_name;
 		enum { FLOAT, STRING } m_valueType;
 		uint32_t m_valueCount;
 		Double4 m_value;
 		String m_stringValue;
-
-		friend Material;
 	};
 
 	class AttributeConvert
@@ -72,6 +69,8 @@ public:
 
 public:
 	bool load(String filePath);
+	void loadPre147Format(String &content);
+	void loadPost147Format(String &content);
 	void destroy();
 
 	/**
@@ -80,11 +79,12 @@ public:
 	 * @param[in] prefix The prefix for each line of generated definition
 	 * @return @c The definition of material
 	 */
-	String toDefinition(const String &prefix = "") const;
+	//String toDefinition(const String &prefix = "") const;
 
 	String toDeclaration(const String &prefix = "") const;
 
-	Pix::Value toPixDefinition() const;
+	Pix::Value toPixDefinitionPre147() const;
+	Pix::Value toPixDefinitionPost147() const;
 	Pix::Value toPixDeclaration() const;
 
 	/**
@@ -98,10 +98,9 @@ public:
 
 	bool convertTextures(String exportPath) const;
 
-	static void convertAttribIfNeeded(Material::Attribute &attrib, const String &effect, const String &attribName, const Array<String> &values, const int startIndex = 0);
+	static void setValues(Material::Attribute &attrib, const Array<String> &values, const int startIndex = 0);
 
 	typedef Map<String, Attribute> AttributesMap; //changed to map since 1.47 to easily insert values to a single old attribute from multiple new attributes
-	typedef Map<String, AttributeConvert> AttributeConvertMap; //since 1.47 - map of new attribute names to old attribute names
 
 private:
 	String m_effect;
@@ -109,8 +108,6 @@ private:
 	AttributesMap m_attributes;
 	String m_filePath;		// @example: /material/example.mat
 	String m_alias;
-
-	static AttributeConvertMap m_convertMap;
 
 	friend Model;
 };

--- a/src/material/material.h
+++ b/src/material/material.h
@@ -47,26 +47,6 @@ public:
 		String m_stringValue;
 	};
 
-	class AttributeConvert
-	{
-	public:
-		AttributeConvert(String oldName, int valueCount, int startIndex);
-	private:
-		String m_oldName;
-		uint32_t m_valueCount;
-		/* some new attributes map to a single old attribute
-		* example:
-		* detail_fadeout_from -> aux[5][0]
-		* detail_fadeout_range -> aux[5][1]
-		* detail_blend_bias -> aux[5][2]
-		* detail_uv_scale -> aux[5][3]
-		* that's why we need the startIndex to insert the value at specified offset
-		*/
-		uint32_t m_startIndex;
-
-		friend Material;
-	};
-
 public:
 	bool load(String filePath);
 	void loadPre147Format(String &content);

--- a/src/material/material_converter_147.cpp
+++ b/src/material/material_converter_147.cpp
@@ -1,0 +1,371 @@
+/******************************************************************************
+ *
+ *  Project:	ConverterPIX @ Core
+ *  File:		/material/material_converter_147.cpp
+ *
+ *		  _____                          _            _____ _______   __
+ *		 / ____|                        | |          |  __ \_   _\ \ / /
+ *		| |     ___  _ ____   _____ _ __| |_ ___ _ __| |__) || |  \ V /
+ *		| |    / _ \| '_ \ \ / / _ \ '__| __/ _ \ '__|  ___/ | |   > <
+ *		| |___| (_) | | | \ V /  __/ |  | ||  __/ |  | |    _| |_ / . \
+ *		 \_____\___/|_| |_|\_/ \___|_|   \__\___|_|  |_|   |_____/_/ \_\
+ *
+ *
+ *  Copyright (C) 2017 Michal Wojtowicz.
+ *  All rights reserved.
+ *
+ *   This software is ditributed WITHOUT ANY WARRANTY; without even
+ *   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *   PURPOSE. See the copyright file for more information.
+ *
+ *****************************************************************************/
+
+#include <prerequisites.h>
+
+#include "material.h"
+#include "material_converter_147.h"
+#include "math/vector.h"
+
+MaterialConverter147::AttributeConvert::AttributeConvert(String name, int valueCount, int startIndex)
+	: m_name(name)
+	, m_valueCount(valueCount)
+	, m_startIndex(startIndex)
+{
+}
+
+MaterialConverter147::AttributeConvertMapPre147 MaterialConverter147::m_convertMapToPre147 = {
+	{ "additional_ambient", MaterialConverter147::AttributeConvert("add_ambient", 1, 0) },
+	{ "glass_tint_color", MaterialConverter147::AttributeConvert("tint", 3, 0) },
+	{ "glass_tint_opacity", MaterialConverter147::AttributeConvert("tint_opacity", 1, 0) },
+	{ "shadowmap_bias", MaterialConverter147::AttributeConvert("shadow_bias", 1, 0) },
+	{ "paintjob_base_color", MaterialConverter147::AttributeConvert("aux[8]", 3, 0) },
+	{ "specular_secondary", MaterialConverter147::AttributeConvert("aux[3]", 4, 0) },
+	{ "shininess_secondary", MaterialConverter147::AttributeConvert("aux[3]", 4, 3) },
+	{ "reflection_secondary", MaterialConverter147::AttributeConvert("reflection2", 1, 0) },
+	{ "lod_selector", MaterialConverter147::AttributeConvert("aux[1]", 1, 0) },
+	{ "shadow_offset", MaterialConverter147::AttributeConvert("aux[0]", 1, 0) },
+	{ "amod_decal_blending_factors", MaterialConverter147::AttributeConvert("amod_decal_blending_factors", 2, 0) }, //not present in materials until 1.47
+	{ "texgen_0_gen", MaterialConverter147::AttributeConvert("aux[0]", 2, 0) },
+	{ "texgen_0_rot", MaterialConverter147::AttributeConvert("texgen_0_rot", 1, 0) }, //not present in materials until 1.47
+	{ "texgen_1_gen", MaterialConverter147::AttributeConvert("aux[1]", 2, 0) },
+	{ "texgen_1_rot", MaterialConverter147::AttributeConvert("texgen_1_rot", 1, 0) }, //not present in materials until 1.47
+	{ "depth_bias", MaterialConverter147::AttributeConvert("aux[0]", 1, 0) },
+	{ "luminance_output", MaterialConverter147::AttributeConvert("aux[5]", 2, 0) },
+	{ "luminance_night", MaterialConverter147::AttributeConvert("aux[5]", 2, 1) },
+	{ "water_distances", MaterialConverter147::AttributeConvert("aux[0]", 3, 0) },
+	{ "water_near_color", MaterialConverter147::AttributeConvert("aux[1]", 3, 0) },
+	{ "water_horizon_color", MaterialConverter147::AttributeConvert("aux[2]", 3, 0) },
+	{ "water_layer_0_yaw", MaterialConverter147::AttributeConvert("aux[3]", 4, 0) },
+	{ "water_layer_0_speed", MaterialConverter147::AttributeConvert("aux[3]", 4, 1) },
+	{ "water_layer_0_scale", MaterialConverter147::AttributeConvert("aux[3]", 4, 2) },
+	{ "water_layer_1_yaw", MaterialConverter147::AttributeConvert("aux[4]", 4, 0) },
+	{ "water_layer_1_speed", MaterialConverter147::AttributeConvert("aux[4]", 4, 1) },
+	{ "water_layer_1_scale", MaterialConverter147::AttributeConvert("aux[4]", 4, 2) },
+	{ "water_mirror", MaterialConverter147::AttributeConvert("aux[5]", 1, 0) },
+	{ "animsheet_cfg_fps", MaterialConverter147::AttributeConvert("aux[0]", 3, 0) },
+	{ "animsheet_cfg_frames_row", MaterialConverter147::AttributeConvert("aux[0]", 3, 1) },
+	{ "animsheet_cfg_frames_total", MaterialConverter147::AttributeConvert("aux[0]", 3, 2) },
+	{ "animsheet_frame_width", MaterialConverter147::AttributeConvert("aux[1]", 2, 0) },
+	{ "animsheet_frame_height", MaterialConverter147::AttributeConvert("aux[1]", 2, 1) },
+	{ "detail_fadeout_from", MaterialConverter147::AttributeConvert("aux[5]", 4, 0) },
+	{ "detail_fadeout_range", MaterialConverter147::AttributeConvert("aux[5]", 4, 1) },
+	{ "detail_blend_bias", MaterialConverter147::AttributeConvert("aux[5]", 4, 2) },
+	{ "detail_uv_scale", MaterialConverter147::AttributeConvert("aux[5]", 4, 3) },
+	{ "animation_speed", MaterialConverter147::AttributeConvert("aux[0]", 1, 0) },
+	{ "showroom_r_color", MaterialConverter147::AttributeConvert("aux[0]", 1, 0) }, //was single float, since 1.47 is 3d vector
+	{ "showroom_speed", MaterialConverter147::AttributeConvert("aux[4]", 3, 0) },
+	{ "flake_uvscale", MaterialConverter147::AttributeConvert("aux[5]", 4, 0) },
+	{ "flake_shininess", MaterialConverter147::AttributeConvert("aux[5]", 4, 1) },
+	{ "flake_clearcoat_rolloff", MaterialConverter147::AttributeConvert("aux[5]", 4, 2) },
+	{ "flake_vratio", MaterialConverter147::AttributeConvert("aux[5]", 4, 3) },
+	{ "flake_color", MaterialConverter147::AttributeConvert("aux[6]", 4, 0) },
+	{ "flake_density", MaterialConverter147::AttributeConvert("aux[6]", 4, 3) },
+	{ "flip_color", MaterialConverter147::AttributeConvert("aux[7]", 4, 0) },
+	{ "flip_strength", MaterialConverter147::AttributeConvert("aux[7]", 4, 3) },
+	{ "mix00_diffuse_secondary", MaterialConverter147::AttributeConvert("mix00_diffuse_secondary", 3, 0) }, //not present in materials until 1.47
+	{ "mult_uvscale", MaterialConverter147::AttributeConvert("aux[5]", 4, 0) },
+	{ "mult_uvscale_secondary", MaterialConverter147::AttributeConvert("aux[5]", 4, 2) },
+	{ "sheet_frame_size_r", MaterialConverter147::AttributeConvert("aux[0]", 4, 0) },
+	{ "sheet_frame_size_g", MaterialConverter147::AttributeConvert("aux[0]", 4, 2) },
+	{ "sheet_frame_size_b", MaterialConverter147::AttributeConvert("aux[1]", 4, 0) },
+	{ "sheet_frame_size_a", MaterialConverter147::AttributeConvert("aux[1]", 4, 2) },
+	{ "paintjob_r_color", MaterialConverter147::AttributeConvert("aux[5]", 3, 0) },
+	{ "paintjob_g_color", MaterialConverter147::AttributeConvert("aux[6]", 3, 0) },
+	{ "paintjob_b_color", MaterialConverter147::AttributeConvert("aux[7]", 3, 0) }
+};
+
+MaterialConverter147::AttributeConvertMapPost147 MaterialConverter147::m_convertMapToPost147 = {
+	{ "add_ambient", { MaterialConverter147::AttributeConvert("additional_ambient", 1, 0) } },
+	{ "shadow_bias", { MaterialConverter147::AttributeConvert("shadowmap_bias", 1, 0) } },
+	{ "tint", { MaterialConverter147::AttributeConvert("glass_tint_color", 3, 0) } },
+	{ "tint_opacity", { MaterialConverter147::AttributeConvert("glass_tint_opacity", 1, 0) } },
+	{ "reflection_secondary", { MaterialConverter147::AttributeConvert("reflection2", 1, 0) } },
+};
+
+MaterialConverter147::AttributeConvertMapPost147 MaterialConverter147::m_convertMapToPost147_TruckpaintRaw = {
+	{ "aux[5]", { MaterialConverter147::AttributeConvert("paintjob_r_color", 3, 0) } },
+	{ "aux[6]", { MaterialConverter147::AttributeConvert("paintjob_g_color", 3, 0) } },
+	{ "aux[7]", { MaterialConverter147::AttributeConvert("paintjob_b_color", 3, 0) } },
+	{ "aux[8]", { MaterialConverter147::AttributeConvert("paintjob_base_color", 3, 0) } }
+};
+
+MaterialConverter147::AttributeConvertMapPost147 MaterialConverter147::m_convertMapToPost147_Flipflake = {
+	{ "aux[5]", {
+		MaterialConverter147::AttributeConvert("flake_uvscale", 1, 0),
+		MaterialConverter147::AttributeConvert("flake_shininess", 1, 1),
+		MaterialConverter147::AttributeConvert("flake_clearcoat_rolloff", 1, 2),
+		MaterialConverter147::AttributeConvert("flake_vratio", 1, 3)
+		}
+	},
+	{ "aux[6]", {
+		MaterialConverter147::AttributeConvert("flake_color", 3, 0),
+		MaterialConverter147::AttributeConvert("flake_density", 1, 3)
+		}
+	},
+	{ "aux[7]", {
+		MaterialConverter147::AttributeConvert("flip_color", 3, 0),
+		MaterialConverter147::AttributeConvert("flip_strength", 1, 3)
+		}
+	},
+	{ "aux[8]", { MaterialConverter147::AttributeConvert("paintjob_base_color", 3, 0) } }
+};
+
+MaterialConverter147::AttributeConvertMapPost147 MaterialConverter147::m_convertMapToPost147_Weight = {
+	{ "aux[3]", {
+		MaterialConverter147::AttributeConvert("specular_secondary", 3, 0),
+		MaterialConverter147::AttributeConvert("shininess_secondary", 1, 3)
+		}
+	},
+};
+
+MaterialConverter147::AttributeConvertMapPost147 MaterialConverter147::m_convertMapToPost147_Leaves = {
+	{ "aux[0]", { MaterialConverter147::AttributeConvert("shadow_offset", 1, 0) } },
+	{ "aux[1]", { MaterialConverter147::AttributeConvert("lod_selector", 1, 0) } }
+};
+
+MaterialConverter147::AttributeConvertMapPost147 MaterialConverter147::m_convertMapToPost147_Tg0Tg1 = {
+	{ "aux[0]", { MaterialConverter147::AttributeConvert("texgen_0_gen", 2, 0) } },
+	{ "aux[1]", { MaterialConverter147::AttributeConvert("texgen_1_gen", 2, 0) } }
+};
+
+MaterialConverter147::AttributeConvertMapPost147 MaterialConverter147::m_convertMapToPost147_Lightmap = {
+	{ "aux[0]", { MaterialConverter147::AttributeConvert("depth_bias", 1, 0) } }
+};
+
+MaterialConverter147::AttributeConvertMapPost147 MaterialConverter147::m_convertMapToPost147_Light = {
+	{ "aux[5]", {
+		MaterialConverter147::AttributeConvert("luminance_output", 1, 0),
+		MaterialConverter147::AttributeConvert("luminance_night", 1, 1) }
+	}
+};
+
+MaterialConverter147::AttributeConvertMapPost147 MaterialConverter147::m_convertMapToPost147_Water = {
+	{ "aux[0]", { MaterialConverter147::AttributeConvert("water_distances", 3, 0) } },
+	{ "aux[1]", { MaterialConverter147::AttributeConvert("water_near_color", 3, 0) } },
+	{ "aux[2]", { MaterialConverter147::AttributeConvert("water_horizon_color", 3, 0) } },
+	{ "aux[3]", {
+		MaterialConverter147::AttributeConvert("water_layer_0_yaw", 1, 0),
+		MaterialConverter147::AttributeConvert("water_layer_0_speed", 1, 1),
+		MaterialConverter147::AttributeConvert("water_layer_0_scale", 2, 2) }
+	},
+	{ "aux[4]", {
+		MaterialConverter147::AttributeConvert("water_layer_1_yaw", 1, 0),
+		MaterialConverter147::AttributeConvert("water_layer_1_speed", 1, 1),
+		MaterialConverter147::AttributeConvert("water_layer_1_scale", 2, 2) }
+	},
+	{ "aux[5]", { MaterialConverter147::AttributeConvert("water_mirror", 1, 0) } }
+};
+
+MaterialConverter147::AttributeConvertMapPost147 MaterialConverter147::m_convertMapToPost147_Animsheet = {
+	{ "aux[0]", {
+		MaterialConverter147::AttributeConvert("animsheet_cfg_fps", 1, 0),
+		MaterialConverter147::AttributeConvert("animsheet_cfg_frames_row", 1, 1),
+		MaterialConverter147::AttributeConvert("animsheet_cfg_frames_total", 1, 2) }
+	},
+	{ "aux[1]", {
+		MaterialConverter147::AttributeConvert("animsheet_frame_width", 1, 0),
+		MaterialConverter147::AttributeConvert("animsheet_frame_height", 1, 1) }
+	}
+};
+
+MaterialConverter147::AttributeConvertMapPost147 MaterialConverter147::m_convertMapToPost147_Detail = {
+	{ "aux[5]", {
+		MaterialConverter147::AttributeConvert("detail_fadeout_from", 1, 0),
+		MaterialConverter147::AttributeConvert("detail_fadeout_range", 1, 1),
+		MaterialConverter147::AttributeConvert("detail_blend_bias", 1, 2),
+		MaterialConverter147::AttributeConvert("detail_uv_scale", 1, 3) }
+	}
+};
+
+MaterialConverter147::AttributeConvertMapPost147 MaterialConverter147::m_convertMapToPost147_Anim = {
+	{ "aux[0]", { MaterialConverter147::AttributeConvert("animation_speed", 1, 0) } }
+};
+
+MaterialConverter147::AttributeConvertMapPost147 MaterialConverter147::m_convertMapToPost147_Showroom = {
+	{ "aux[0]", { MaterialConverter147::AttributeConvert("showroom_r_color", 3, 0) } }, //was single float, since 1.47 is 3d vector
+	{ "aux[4]", { MaterialConverter147::AttributeConvert("showroom_speed", 3, 0) } }
+};
+
+MaterialConverter147::AttributeConvertMapPost147 MaterialConverter147::m_convertMapToPost147_Mult = {
+	{ "aux[5]", {
+		MaterialConverter147::AttributeConvert("mult_uvscale", 2, 0) }
+	}
+};
+
+MaterialConverter147::AttributeConvertMapPost147 MaterialConverter147::m_convertMapToPost147_Mult2 = {
+	{ "aux[5]", {
+		MaterialConverter147::AttributeConvert("mult_uvscale_secondary", 2, 2) }
+	}
+};
+
+MaterialConverter147::AttributeConvertMapPost147 MaterialConverter147::m_convertMapToPost147_LampAnim = {
+	{ "aux[0]", {
+		MaterialConverter147::AttributeConvert("sheet_frame_size_r", 2, 0),
+		MaterialConverter147::AttributeConvert("sheet_frame_size_g", 2, 2) }
+	},
+	{ "aux[1]", {
+		MaterialConverter147::AttributeConvert("sheet_frame_size_b", 4, 0),
+		MaterialConverter147::AttributeConvert("sheet_frame_size_a", 4, 2) }
+	}
+};
+
+bool MaterialConverter147::convertAttributesToPost147Format(const String &effectName, const String &attrName, const Array<String> &attrValues, Material::AttributesMap &outAttributes)
+{
+	auto checkAndWriteAttributes = [&] (auto &convertMapToPost147) {
+		auto convertRule = convertMapToPost147.find(attrName);
+		if (convertRule != convertMapToPost147.end())
+		{
+			for (auto it = convertRule->second.begin(); it != convertRule->second.end(); ++it)
+			{
+				Material::Attribute& newAttr = outAttributes[(*it).m_name];
+				newAttr.m_name = (*it).m_name;
+				newAttr.m_valueType = Material::Attribute::FLOAT;
+				newAttr.m_valueCount = (*it).m_valueCount;
+
+				Material::setValues(newAttr, attrValues, (*it).m_startIndex);
+				//info_f("material", effectName, "Converted attribute to post 1.47 format: %s -> %s(%s)", attrName.c_str(), newAttr.m_name.c_str(), prism::to_string(newAttr.m_value).c_str());
+			}
+			return true;
+		}
+		return false;
+	};
+
+	if (checkAndWriteAttributes(m_convertMapToPost147))
+		return true;
+
+	if (effectName.find("dif.spec.weight") != String::npos) //aux[3]
+	{
+		if (checkAndWriteAttributes(m_convertMapToPost147_Weight))
+			return true;
+	}
+
+	if (effectName.find("dif.spec.weight.mult2.weight2") != String::npos) //aux[5]
+	{
+		if (checkAndWriteAttributes(m_convertMapToPost147_Mult2))
+			return true;
+	}
+
+	if (effectName.find("dif.spec.weight.mult2") != String::npos) //aux[5]
+	{
+		if (checkAndWriteAttributes(m_convertMapToPost147_Mult))
+			return true;
+	}
+
+	if (effectName.find("leaves") != String::npos) //aux[0], aux[1]
+	{
+		if (checkAndWriteAttributes(m_convertMapToPost147_Leaves))
+			return true;
+	}
+
+	if (effectName.find("tg0") != String::npos || effectName.find("tg1") != String::npos) //aux[0], aux[1]
+	{
+		if (checkAndWriteAttributes(m_convertMapToPost147_Tg0Tg1))
+			return true;
+	}
+
+	if (effectName.find("light") != String::npos) //aux[0]
+	{
+		if (checkAndWriteAttributes(m_convertMapToPost147_Lightmap))
+			return true;
+	}
+
+	if (effectName.find("night") != String::npos || effectName.find("flare") != String::npos
+		|| effectName.find("unlit") != String::npos || effectName.find(".lum") != String::npos
+		|| effectName.find("light.tex") != String::npos) //aux[5]
+	{
+		if (checkAndWriteAttributes(m_convertMapToPost147_Light))
+			return true;
+	}
+
+	if (effectName.find("water") != String::npos) //aux[0], aux[1], aux[2], aux[3], aux[4], aux[5]
+	{
+		if (checkAndWriteAttributes(m_convertMapToPost147_Water))
+			return true;
+	}
+
+	if (effectName.find(".flipsheet") != String::npos || effectName.find(".fadesheet") != String::npos
+		|| effectName.find(".bounce") != String::npos) //aux[0], aux[1]
+	{
+		if (checkAndWriteAttributes(m_convertMapToPost147_Animsheet))
+			return true;
+	}
+
+	if (effectName.find(".fade.") != String::npos) //aux[5]
+	{
+		if (checkAndWriteAttributes(m_convertMapToPost147_Detail))
+			return true;
+	}
+
+	if (effectName.find("lamp.anim") != String::npos)
+	{
+		if (checkAndWriteAttributes(m_convertMapToPost147_LampAnim)) //aux[0], aux[1]
+			return true;
+	}
+	else if (effectName.find(".anim.") != String::npos) //aux[0]
+	{
+		if (checkAndWriteAttributes(m_convertMapToPost147_Anim))
+			return true;
+	}
+
+	if (effectName.find("showroom_v2") != String::npos) //aux[0], aux[4]
+	{
+		if (checkAndWriteAttributes(m_convertMapToPost147_Showroom))
+			return true;
+	}
+
+	if (effectName.find("flipflake") != String::npos) //aux[5], aux[6], aux[7], aux[8]
+	{
+		if (checkAndWriteAttributes(m_convertMapToPost147_Flipflake))
+			return true;
+	}
+	else if (effectName.find("truckpaint") != String::npos) //aux[5], aux[6], aux[7], aux[8]
+	{
+		if (checkAndWriteAttributes(m_convertMapToPost147_TruckpaintRaw))
+			return true;
+	}
+
+
+	return false;
+}
+
+void MaterialConverter147::convertAttributesToPre147Format(const String &effect, const Material::AttributesMap& inAttributes, Material::AttributesMap& outAttributes)
+{
+	for (auto attribute : inAttributes)
+	{
+		AttributeConvertMapPre147::iterator convertRule = m_convertMapToPre147.find(attribute.second.m_name);
+		if (convertRule != m_convertMapToPre147.end())
+		{
+			Material::Attribute &convertedAttribute = outAttributes[convertRule->second.m_name];
+			convertedAttribute.m_name = convertRule->second.m_name;
+			convertedAttribute.m_valueCount = convertRule->second.m_valueCount;
+			convertedAttribute.m_valueType = attribute.second.m_valueType;
+			for (uint32_t i=0; i<attribute.second.m_valueCount; i++)
+			{
+				convertedAttribute.m_value[convertRule->second.m_startIndex+i] = attribute.second.m_value[i];
+			}
+			//info_f("material", effect, "Converted attribute to pre 1.47 format: %s(%s) -> %s(%s)", attribute.second.m_name.c_str(), prism::to_string(attribute.second.m_value).c_str(), convertedAttribute.m_name.c_str(), prism::to_string(convertedAttribute.m_value).c_str());
+		}
+		else
+			outAttributes[attribute.first] = attribute.second;
+	}
+}

--- a/src/material/material_converter_147.h
+++ b/src/material/material_converter_147.h
@@ -1,0 +1,72 @@
+/******************************************************************************
+ *
+ *  Project:	ConverterPIX @ Core
+ *  File:		/material/material_converter_147.h
+ *
+ *		  _____                          _            _____ _______   __
+ *		 / ____|                        | |          |  __ \_   _\ \ / /
+ *		| |     ___  _ ____   _____ _ __| |_ ___ _ __| |__) || |  \ V /
+ *		| |    / _ \| '_ \ \ / / _ \ '__| __/ _ \ '__|  ___/ | |   > <
+ *		| |___| (_) | | | \ V /  __/ |  | ||  __/ |  | |    _| |_ / . \
+ *		 \_____\___/|_| |_|\_/ \___|_|   \__\___|_|  |_|   |_____/_/ \_\
+ *
+ *
+ *  Copyright (C) 2017 Michal Wojtowicz.
+ *  All rights reserved.
+ *
+ *   This software is ditributed WITHOUT ANY WARRANTY; without even
+ *   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *   PURPOSE. See the copyright file for more information.
+ *
+ *****************************************************************************/
+
+#pragma once
+
+class MaterialConverter147
+{
+	class AttributeConvert
+	{
+	public:
+		AttributeConvert(String name, int valueCount, int startIndex);
+	private:
+		String m_name;
+		uint32_t m_valueCount;
+		/* some new attributes map to a single old attribute
+		* example:
+		* detail_fadeout_from -> aux[5][0]
+		* detail_fadeout_range -> aux[5][1]
+		* detail_blend_bias -> aux[5][2]
+		* detail_uv_scale -> aux[5][3]
+		* that's why we need the startIndex to insert the value at specified offset
+		*/
+		uint32_t m_startIndex;
+
+		friend MaterialConverter147;
+	};
+
+	typedef Map<String, AttributeConvert> AttributeConvertMapPre147; //since 1.47 - map of new attribute names to old attribute names
+	typedef Map<String, Array<AttributeConvert> > AttributeConvertMapPost147; //since 1.47 - map of new attribute names to old attribute names
+
+	static AttributeConvertMapPre147 m_convertMapToPre147;
+
+	static AttributeConvertMapPost147 m_convertMapToPost147;
+	static AttributeConvertMapPost147 m_convertMapToPost147_TruckpaintRaw;
+	static AttributeConvertMapPost147 m_convertMapToPost147_Flipflake;
+	static AttributeConvertMapPost147 m_convertMapToPost147_Weight;
+	static AttributeConvertMapPost147 m_convertMapToPost147_Leaves;
+	static AttributeConvertMapPost147 m_convertMapToPost147_Tg0Tg1;
+	static AttributeConvertMapPost147 m_convertMapToPost147_Lightmap;
+	static AttributeConvertMapPost147 m_convertMapToPost147_Light;
+	static AttributeConvertMapPost147 m_convertMapToPost147_Water;
+	static AttributeConvertMapPost147 m_convertMapToPost147_Animsheet;
+	static AttributeConvertMapPost147 m_convertMapToPost147_Detail;
+	static AttributeConvertMapPost147 m_convertMapToPost147_Anim;
+	static AttributeConvertMapPost147 m_convertMapToPost147_Showroom;
+	static AttributeConvertMapPost147 m_convertMapToPost147_Mult;
+	static AttributeConvertMapPost147 m_convertMapToPost147_Mult2;
+	static AttributeConvertMapPost147 m_convertMapToPost147_LampAnim;
+
+public:
+	static bool convertAttributesToPost147Format(const String &effectName, const String &attrName, const Array<String> &attrValues, Material::AttributesMap &outAttributes);
+	static void convertAttributesToPre147Format(const String &effect, const Material::AttributesMap &inAttributes, Material::AttributesMap &outAttributes);
+};

--- a/src/material/material_converter_147.h
+++ b/src/material/material_converter_147.h
@@ -44,8 +44,8 @@ class MaterialConverter147
 		friend MaterialConverter147;
 	};
 
-	typedef Map<String, AttributeConvert> AttributeConvertMapPre147; //since 1.47 - map of new attribute names to old attribute names
-	typedef Map<String, Array<AttributeConvert> > AttributeConvertMapPost147; //since 1.47 - map of new attribute names to old attribute names
+	using AttributeConvertMapPre147 = Map<String, AttributeConvert>; // map of new attribute names to old attribute names
+	using AttributeConvertMapPost147 = Map<String, Array<AttributeConvert> >; // map of old attribute names to new attribute names
 
 	static AttributeConvertMapPre147 m_convertMapToPre147;
 

--- a/src/material/material_post_147.cpp
+++ b/src/material/material_post_147.cpp
@@ -1,0 +1,176 @@
+/******************************************************************************
+ *
+ *  Project:	ConverterPIX @ Core
+ *  File:		/material/material_post_147.cpp
+ *
+ *		  _____                          _            _____ _______   __
+ *		 / ____|                        | |          |  __ \_   _\ \ / /
+ *		| |     ___  _ ____   _____ _ __| |_ ___ _ __| |__) || |  \ V /
+ *		| |    / _ \| '_ \ \ / / _ \ '__| __/ _ \ '__|  ___/ | |   > <
+ *		| |___| (_) | | | \ V /  __/ |  | ||  __/ |  | |    _| |_ / . \
+ *		 \_____\___/|_| |_|\_/ \___|_|   \__\___|_|  |_|   |_____/_/ \_\
+ *
+ *
+ *  Copyright (C) 2017 Michal Wojtowicz.
+ *  All rights reserved.
+ *
+ *   This software is ditributed WITHOUT ANY WARRANTY; without even
+ *   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *   PURPOSE. See the copyright file for more information.
+ *
+ *****************************************************************************/
+
+#include <prerequisites.h>
+
+#include "material.h"
+
+#include <texture/texture.h>
+
+void Material::loadPost147Format(String& content)
+{
+	std::stringstream ssbuffer(content);
+
+	while (std::getline(ssbuffer, content))
+	{
+		size_t middle = content.find(':');
+		if (middle == String::npos)
+		{
+			continue;
+		}
+
+		const String name = removeSpaces(content.substr(0, middle));
+		const String nameWithoutIndex = removeSpaces(name.substr(0, name.find('[')));
+		String value = removeSpaces(content.substr(middle + 1));
+
+		Array<String> values;
+
+		size_t braceLeft = value.find('{');
+		size_t quoteLeft = value.find('\"');
+
+		if (braceLeft != String::npos)
+		{
+			if (name == "texture")
+			{
+				/* handles the new format of texture attribute since 1.47
+				* texture : "texture_name" {
+				*	source : "texture_path"
+				* }
+				*/
+
+				String textureType = betweenQuotes(value);
+				if (textureType == "ERROR")
+				{
+					warning("material", m_filePath, "Unable to parse texture type!");
+					continue;
+				}
+				std::getline(ssbuffer, content); //assuming the "source" attribute is in the next line
+				middle = content.find(':');
+				if (removeSpaces(content.substr(0, middle)) != "source")
+				{
+					warning("material", m_filePath, "Unexpected texture attribute: " + removeSpaces(content.substr(0, middle)));
+					continue;
+				}
+				value = removeSpaces(content.substr(middle + 1));
+				quoteLeft = value.find('\"');
+				if (quoteLeft != String::npos)
+				{
+					value = betweenQuotes(value);
+				}
+
+				Texture newTexture;
+				newTexture.m_texture = value[0] == '/' ? value.c_str() : directory(m_filePath) + "/" + value.c_str();
+				newTexture.m_textureName = textureType;
+				m_textures.push_back(newTexture);
+
+				std::getline(ssbuffer, content); //read the closing brace
+				continue;
+			}
+			else
+			{
+				size_t braceRight = value.find('}');
+				if (braceRight == String::npos)
+				{
+					warning("material", m_filePath, "Unable to find closing brace!");
+					continue;
+				}
+				String valuesArray = value.substr(braceLeft + 1, braceRight - braceLeft - 1);
+				std::replace_if(valuesArray.begin(), valuesArray.end(), [](char ch)->bool { return ch == ','; }, ' ');
+
+				char valuesArray2[128] = { 0 }, tempValue[128] = { 0 };
+				strcpy(valuesArray2, valuesArray.c_str());
+				const char* valuesArrayptr = valuesArray2;
+				while (sscanf(valuesArrayptr, "%s", tempValue) != EOF)
+				{
+					values.push_back(tempValue);
+					valuesArrayptr += strlen(tempValue) + 1;
+				}
+			}
+		}
+		else if (quoteLeft != String::npos)
+		{
+			value = betweenQuotes(value);
+		}
+		else
+		{
+			values.push_back(value);
+		}
+
+		if (name != "queue_bias" && name != "texture")
+		{
+			Attribute& attrib = m_attributes[name];
+			attrib.m_name = name;
+
+			if (values.size() > 0)
+			{
+				if (values.size() > 4)
+				{
+					warning("material", m_filePath, "Too many values in the attribute!");
+					continue;
+				}
+				attrib.m_valueType = Attribute::FLOAT;
+				attrib.m_valueCount = values.size();
+
+				setValues(attrib, values, 0);
+			}
+			else
+			{
+				attrib.m_valueType = Attribute::STRING;
+				attrib.m_stringValue = value.c_str();
+			}
+		}
+	}
+}
+
+Pix::Value Material::toPixDefinitionPost147() const
+{
+	Pix::Value root;
+	root["Alias"] = alias();
+	root["Effect"] = m_effect;
+	root["Flags"] = 0;
+	root["AttributeCount"] = m_attributes.size();
+	root["TextureCount"] = m_textures.size();
+
+	for (AttributesMap::const_iterator it = m_attributes.begin(); it != m_attributes.end(); ++it)
+	{
+		Pix::Value& attribute = root["Attribute"];
+		attribute["Format"] = Pix::Value::Enumeration(it->second.getFormat());
+		attribute["Tag"] = it->second.m_name;
+		if (it->second.m_valueType == Attribute::FLOAT)
+		{
+			attribute["Value"] = Pix::Value(it->second.m_value, it->second.m_valueCount);
+		}
+		else
+		{
+			attribute["Value"] = Pix::Value::Enumeration("( \"" + it->second.m_stringValue + "\" )");
+		}
+	}
+
+	for (size_t i = 0; i < m_textures.size(); ++i)
+	{
+		const Texture* const tex = &m_textures[i];
+		Pix::Value& texture = root["Texture"];
+		texture["Tag"] = fmt::sprintf("texture[%i]:%s", (int)i, tex->m_textureName);
+		texture["Value"] = tex->m_texture.substr(0, tex->m_texture.length() - 5); // -5 -> .tobj removing
+	}
+	return root;
+}

--- a/src/material/material_pre_147.cpp
+++ b/src/material/material_pre_147.cpp
@@ -1,0 +1,174 @@
+/******************************************************************************
+ *
+ *  Project:	ConverterPIX @ Core
+ *  File:		/material/material_pre_147.cpp
+ *
+ *		  _____                          _            _____ _______   __
+ *		 / ____|                        | |          |  __ \_   _\ \ / /
+ *		| |     ___  _ ____   _____ _ __| |_ ___ _ __| |__) || |  \ V /
+ *		| |    / _ \| '_ \ \ / / _ \ '__| __/ _ \ '__|  ___/ | |   > <
+ *		| |___| (_) | | | \ V /  __/ |  | ||  __/ |  | |    _| |_ / . \
+ *		 \_____\___/|_| |_|\_/ \___|_|   \__\___|_|  |_|   |_____/_/ \_\
+ *
+ *
+ *  Copyright (C) 2017 Michal Wojtowicz.
+ *  All rights reserved.
+ *
+ *   This software is ditributed WITHOUT ANY WARRANTY; without even
+ *   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *   PURPOSE. See the copyright file for more information.
+ *
+ *****************************************************************************/
+
+#include <prerequisites.h>
+
+#include "material.h"
+#include "material_converter_147.h"
+
+#include <texture/texture.h>
+
+void Material::loadPre147Format(String& content)
+{
+	std::stringstream ssbuffer(content);
+
+	while (std::getline(ssbuffer, content))
+	{
+		size_t middle = content.find(':');
+		if (middle == String::npos)
+		{
+			continue;
+		}
+
+		const String name = removeSpaces(content.substr(0, middle));
+		const String nameWithoutIndex = removeSpaces(name.substr(0, name.find('[')));
+		String value = removeSpaces(content.substr(middle + 1));
+
+		Array<String> values;
+
+		size_t braceLeft = value.find('{');
+		size_t quoteLeft = value.find('\"');
+
+		if (braceLeft != String::npos)
+		{
+			size_t braceRight = value.find('}');
+			if (braceRight == String::npos)
+			{
+				warning("material", m_filePath, "Unable to find closing brace!");
+				continue;
+			}
+			String valuesArray = value.substr(braceLeft + 1, braceRight - braceLeft - 1);
+			std::replace_if(valuesArray.begin(), valuesArray.end(), [](char ch)->bool { return ch == ','; }, ' ');
+
+			char valuesArray2[128] = { 0 }, tempValue[128] = { 0 };
+			strcpy(valuesArray2, valuesArray.c_str());
+			const char* valuesArrayptr = valuesArray2;
+			while (sscanf(valuesArrayptr, "%s", tempValue) != EOF)
+			{
+				values.push_back(tempValue);
+				valuesArrayptr += strlen(tempValue) + 1;
+			}
+		}
+		else if (quoteLeft != String::npos)
+		{
+			value = betweenQuotes(value);
+		}
+		else
+		{
+			values.push_back(value);
+		}
+
+		if ((nameWithoutIndex == "texture" || nameWithoutIndex == "texture_name"))
+		{
+			//handles the old format of texture attribute
+			auto textureProperty = [&]()->int {
+				int indexTexture = 0;
+				size_t indexBraceLeft = name.find('[');
+				size_t indexBraceRight = name.find(']');
+				if (indexBraceLeft != String::npos && indexBraceRight != String::npos)
+				{
+					indexTexture = atoi(name.substr(indexBraceLeft + 1, indexBraceRight - 1).c_str());
+				}
+				if (indexTexture >= (int)m_textures.size())
+				{
+					m_textures.resize(indexTexture + 1);
+				}
+				return indexTexture;
+			};
+
+			if (nameWithoutIndex == "texture_name")
+			{
+				m_textures[textureProperty()].m_textureName = value.c_str();
+			}
+			else if (nameWithoutIndex == "texture")
+			{
+				m_textures[textureProperty()].m_texture = value[0] == '/' ? value.c_str() : directory(m_filePath) + "/" + value.c_str();
+			}
+		}
+		else if (name != "queue_bias")
+		{
+			if (values.size() > 0)
+			{
+				if (values.size() > 4)
+				{
+					warning("material", m_filePath, "Too many values in the attribute!");
+					continue;
+				}
+
+				if (!MaterialConverter147::convertAttributesToPost147Format(m_effect, name, values, m_attributes))
+				{
+					//attribute is in common format
+					Attribute& attrib = m_attributes[name];
+					attrib.m_name = name;
+					attrib.m_valueType = Attribute::FLOAT;
+					attrib.m_valueCount = values.size();
+
+					setValues(attrib, values, 0);
+				}
+			}
+			else
+			{
+				Attribute& attrib = m_attributes[name];
+				attrib.m_name = name;
+				attrib.m_valueType = Attribute::STRING;
+				attrib.m_stringValue = value.c_str();
+			}
+		}
+	}
+}
+
+Pix::Value Material::toPixDefinitionPre147() const
+{
+	AttributesMap pre147Attributes;
+	MaterialConverter147::convertAttributesToPre147Format(m_effect, m_attributes, pre147Attributes);
+
+	Pix::Value root;
+	root["Alias"] = alias();
+	root["Effect"] = m_effect;
+	root["Flags"] = 0;
+	root["AttributeCount"] = pre147Attributes.size();
+	root["TextureCount"] = m_textures.size();
+
+	for (AttributesMap::const_iterator it = pre147Attributes.begin(); it != pre147Attributes.end(); ++it)
+	{
+		Pix::Value& attribute = root["Attribute"];
+		attribute["Format"] = Pix::Value::Enumeration(it->second.getFormat());
+		attribute["Tag"] = it->second.m_name;
+		if (it->second.m_valueType == Attribute::FLOAT)
+		{
+			attribute["Value"] = Pix::Value(it->second.m_value, it->second.m_valueCount);
+		}
+		else
+		{
+			attribute["Value"] = Pix::Value::Enumeration("( \"" + it->second.m_stringValue + "\" )");
+		}
+	}
+
+	for (size_t i = 0; i < m_textures.size(); ++i)
+	{
+		const Texture* const tex = &m_textures[i];
+		Pix::Value& texture = root["Texture"];
+		texture["Tag"] = fmt::sprintf("texture[%i]:%s", (int)i, tex->m_textureName);
+		texture["Value"] = tex->m_texture.substr(0, tex->m_texture.length() - 5); // -5 -> .tobj removing
+	}
+	return root;
+}

--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -1503,7 +1503,7 @@ bool Model::saveToPit(String exportPath) const
 		look["Name"] = l.m_name;
 		for (const auto &mat : l.m_materials)
 		{
-			look["Material"] = mat.toPixDefinitionPre147();
+			look["Material"] = mat.toPixDefinition();
 		}
 	}
 

--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -1503,7 +1503,7 @@ bool Model::saveToPit(String exportPath) const
 		look["Name"] = l.m_name;
 		for (const auto &mat : l.m_materials)
 		{
-			look["Material"] = mat.toPixDefinition();
+			look["Material"] = mat.toPixDefinitionPre147();
 		}
 	}
 


### PR DESCRIPTION
Support for post 1.47 .mat format.  In this update all the "aux" attributes were renamed to comprehensible names and textures are now stored in objects instead of arrays. Internally we store the attributes in the newest format so conversion must be done when reading pre 1.47 .mat files. Currently we also need to convert back to pre 1.47 format when writing to piX files because SCS Blender Tools don't understand new attribute names.