### PR TITLE
Support for additional Texture object attributes

### DIFF
--- a/src/math/vector.h
+++ b/src/math/vector.h
@@ -177,7 +177,7 @@ namespace prism
 		String result;
 		for (int i = 0; i < N; ++i)
 		{
-			result += String(i == 0 ? "" : "  ") + fmt::sprintf(FLT_FT, dlh(vec[i]));
+			result += String(i == 0 ? "" : "  ") + fmt::sprintf(DBL_FT, dlh(vec[i]));
 		}
 		return result;
 	}

--- a/src/math/vector.h
+++ b/src/math/vector.h
@@ -172,6 +172,17 @@ namespace prism
 	}
 
 	template < size_t N >
+	static String to_string(const prism::vec_t<double, N>& vec)
+	{
+		String result;
+		for (int i = 0; i < N; ++i)
+		{
+			result += String(i == 0 ? "" : "  ") + fmt::sprintf(FLT_FT, dlh(vec[i]));
+		}
+		return result;
+	}
+
+	template < size_t N >
 	static String to_string(const int (&vec)[N])
 	{
 		String result;

--- a/src/prerequisites.h
+++ b/src/prerequisites.h
@@ -108,7 +108,7 @@ using Pair			= std::pair<FIRST, SECOND>;
 #define TAB		"     "
 #define SEOL	"\n"
 #define FLT_FT	"&%08x"
-#define DLT_FT	"&%016x"
+#define DBL_FT	"&%016x"
 
 #ifndef MAX_PATH
 #define MAX_PATH 260

--- a/src/prerequisites.h
+++ b/src/prerequisites.h
@@ -108,6 +108,7 @@ using Pair			= std::pair<FIRST, SECOND>;
 #define TAB		"     "
 #define SEOL	"\n"
 #define FLT_FT	"&%08x"
+#define DLT_FT	"&%016x"
 
 #ifndef MAX_PATH
 #define MAX_PATH 260
@@ -200,6 +201,11 @@ double lin2s(double x);
 inline uint32_t flh(float x)
 {
 	return *(uint32_t *)(&x);
+}
+
+inline uint64_t dlh(double x)
+{
+	return *(uint64_t*)(&x);
 }
 
 String removeSpaces(String str);

--- a/src/texture/texture.cpp
+++ b/src/texture/texture.cpp
@@ -22,6 +22,7 @@
 
 #include <prerequisites.h>
 
+#include "material/material.h"
 #include "texture.h"
 
 #include <resource_lib.h>

--- a/src/texture/texture.h
+++ b/src/texture/texture.h
@@ -33,6 +33,8 @@ private:
 	String m_texture;
 	String m_textureName;
 
+	Array<Material::Attribute> m_attributes;
+
 	SharedPtr<TextureObject> m_texObj;
 
 	friend Material;


### PR DESCRIPTION
- Added support for additional Texture object attributes in material files introduced in game version 1.48. For now converter is only storing them in memory, not writing to output files.
- Utility function to_string() for vectors with elements of double type.