### PR TITLE
Support for PPD 0x19 and new attribute

### DIFF
--- a/src/prefab/prefab.cpp
+++ b/src/prefab/prefab.cpp
@@ -32,6 +32,7 @@
 #include <structs/ppd_0x16.h>
 #include <structs/ppd_0x17.h>
 #include <structs/ppd_0x18.h>
+#include <structs/ppd_0x19.h>
 
 #include <prefab/node.h>
 #include <prefab/curve.h>
@@ -77,11 +78,12 @@ bool Prefab::load(String filePath)
 		case ppd_0x16::ppd_header_t::SUPPORTED_VERSION: return loadVersion0x16(buffer.get(), fileSize);
 		case ppd_0x17::ppd_header_t::SUPPORTED_VERSION: return loadVersion0x17(buffer.get(), fileSize);
 		case ppd_0x18::ppd_header_t::SUPPORTED_VERSION: return loadVersion0x18(buffer.get(), fileSize);
+		case ppd_0x19::ppd_header_t::SUPPORTED_VERSION: return loadVersion0x19(buffer.get(), fileSize);
 	}
 
-	error_f("model", m_filePath, "Invalid version of prefab file (have: %i expected: %i, %i, %i or %i)", version,
+	error_f("model", m_filePath, "Invalid version of prefab file (have: %i expected: %i, %i, %i, %i or %i)", version,
 			ppd_0x15::ppd_header_t::SUPPORTED_VERSION, ppd_0x16::ppd_header_t::SUPPORTED_VERSION, ppd_0x17::ppd_header_t::SUPPORTED_VERSION,
-			ppd_0x18::ppd_header_t::SUPPORTED_VERSION);
+			ppd_0x18::ppd_header_t::SUPPORTED_VERSION, ppd_0x19::ppd_header_t::SUPPORTED_VERSION);
 
 	return false;
 }
@@ -557,7 +559,7 @@ bool Prefab::loadVersion0x17(const uint8_t * const buffer, const size_t fileSize
 	return true;
 }
 
-bool Prefab::loadVersion0x18( const uint8_t *const buffer, const size_t fileSize )
+bool Prefab::loadVersion0x18(const uint8_t * const buffer, const size_t fileSize)
 {
 	using namespace prism::ppd_0x18;
 
@@ -709,6 +711,164 @@ bool Prefab::loadVersion0x18( const uint8_t *const buffer, const size_t fileSize
 		intersection.m_radius = is->m_inter_radius;
 		intersection.m_flags = is->m_flags;
 		m_intersections.push_back( intersection );
+	}
+
+	m_loaded = true;
+	return true;
+}
+
+bool Prefab::loadVersion0x19(const uint8_t * const buffer, const size_t fileSize)
+{
+	using namespace prism::ppd_0x19;
+
+	const ppd_header_t* const header = (ppd_header_t*)(buffer);
+
+	if (header->m_node_offset > fileSize
+		|| header->m_nav_curve_offset > fileSize
+		|| header->m_sign_offset > fileSize
+		|| header->m_semaphore_offset > fileSize
+		|| header->m_spawn_point_offset > fileSize
+		|| header->m_terrain_point_pos_offset > fileSize
+		|| header->m_terrain_point_normal_offset > fileSize
+		|| header->m_terrain_point_variant_offset > fileSize
+		|| header->m_map_point_offset > fileSize
+		|| header->m_trigger_point_offset > fileSize
+		|| header->m_intersection_offset > fileSize)
+	{
+		error_f("prefab", m_filePath, "Offset inside file exceeds file size!");
+		return false;
+	}
+
+	Node node; Curve curve; Sign sign; Semaphore semaphore; SpawnPoint spawnPoint; MapPoint mapPoint;
+	TerrainPointVariant terrainPointVariant; TriggerPoint triggerPoint; Intersection intersection;
+	TerrainPoint terrainPoint;
+
+	for (u32 i = 0; i < header->m_node_count; ++i)
+	{
+		ppd_node_t* fnode = (ppd_node_t*)(buffer + header->m_node_offset) + i;
+		node.m_terrainPointIdx = fnode->m_terrain_point_idx;
+		node.m_terrainPointCount = fnode->m_terrain_point_count;
+		node.m_variantIdx = fnode->m_variant_idx;
+		node.m_variantCount = fnode->m_variant_count;
+		node.m_position = fnode->m_pos;
+		node.m_direction = fnode->m_dir;
+		for (u32 j = 0; j < 8; ++j)
+		{
+			node.m_inputLines[j] = fnode->m_input_lines[j];
+			node.m_outputLines[j] = fnode->m_output_lines[j];
+		}
+		m_nodes.push_back(node);
+	}
+
+	for (u32 i = 0; i < header->m_nav_curve_count; ++i)
+	{
+		ppd_curve_t* fcurve = (ppd_curve_t*)(buffer + header->m_nav_curve_offset) + i;
+		curve.m_name = token_to_string(fcurve->m_name);
+		curve.m_flags = fcurve->m_flags;
+		curve.m_leadsToNodes = fcurve->m_leads_to_nodes;
+		curve.m_startPosition = fcurve->m_start_pos;
+		curve.m_startRotation = fcurve->m_start_rot;
+		curve.m_endPosition = fcurve->m_end_pos;
+		curve.m_endRotation = fcurve->m_end_rot;
+		curve.m_length = fcurve->m_length;
+		for (u32 j = 0; j < 4; ++j)
+		{
+			curve.m_nextLines[j] = fcurve->m_next_lines[j];
+			curve.m_prevLines[j] = fcurve->m_prev_lines[j];
+		}
+		curve.m_nextLinesCount = fcurve->m_count_next;
+		curve.m_prevLinesCount = fcurve->m_count_prev;
+		curve.m_semaphoreId = fcurve->m_semaphore_id;
+		curve.m_trafficRule = token_to_string(fcurve->m_traffic_rule);
+		m_curves.push_back(curve);
+	}
+
+	for (u32 i = 0; i < header->m_sign_count; ++i)
+	{
+		ppd_sign_t* fsign = (ppd_sign_t*)(buffer + header->m_sign_offset) + i;
+		sign.m_name = token_to_string(fsign->m_name);
+		sign.m_position = fsign->m_position;
+		sign.m_rotation = fsign->m_rotation;
+		sign.m_model = token_to_string(fsign->m_model);
+		sign.m_part = token_to_string(fsign->m_part);
+		m_signs.push_back(sign);
+	}
+
+	for (u32 i = 0; i < header->m_semaphore_count; ++i)
+	{
+		ppd_semaphore_t* fsemaphore = (ppd_semaphore_t*)(buffer + header->m_semaphore_offset) + i;
+		semaphore.m_position = fsemaphore->m_position;
+		semaphore.m_rotation = fsemaphore->m_rotation;
+		semaphore.m_type = fsemaphore->m_type;
+		semaphore.m_semaphoreId = fsemaphore->m_semaphore_id;
+		semaphore.m_intervals = fsemaphore->m_intervals;
+		semaphore.m_cycle = fsemaphore->m_cycle;
+		semaphore.m_profile = token_to_string(fsemaphore->m_profile);
+		m_semaphores.push_back(semaphore);
+	}
+
+	for (u32 i = 0; i < header->m_spawn_point_count; ++i)
+	{
+		ppd_spawn_point_t* fspawnpt = (ppd_spawn_point_t*)(buffer + header->m_spawn_point_offset) + i;
+		spawnPoint.m_position = fspawnpt->m_position;
+		spawnPoint.m_rotation = fspawnpt->m_rotation;
+		spawnPoint.m_type = fspawnpt->m_type;
+		spawnPoint.m_flags = fspawnpt->m_flags;
+		m_spawnPoints.push_back(spawnPoint);
+	}
+
+	for (u32 i = 0; i < header->m_terrain_point_count; ++i)
+	{
+		terrainPoint.m_position = *((float3*)(buffer + header->m_terrain_point_pos_offset) + i);
+		terrainPoint.m_normal = *((float3*)(buffer + header->m_terrain_point_normal_offset) + i);
+		m_terrainPoints.push_back(terrainPoint);
+	}
+
+	for (u32 i = 0; i < header->m_terrain_point_variant_count; ++i)
+	{
+		ppd_terrain_point_variant_t* ftpv = (ppd_terrain_point_variant_t*)(buffer + header->m_terrain_point_variant_offset) + i;
+		terrainPointVariant.m_attach0 = ftpv->m_attach0;
+		terrainPointVariant.m_attach1 = ftpv->m_attach1;
+		m_terrainPointVariants.push_back(terrainPointVariant);
+	}
+
+	for (u32 i = 0; i < header->m_map_point_count; ++i)
+	{
+		ppd_map_point_t* fmappt = (ppd_map_point_t*)(buffer + header->m_map_point_offset) + i;
+		mapPoint.m_mapVisualFlags = fmappt->m_map_visual_flags;
+		mapPoint.m_mapNavFlags = fmappt->m_map_nav_flags;
+		mapPoint.m_position = fmappt->m_position;
+		for (u32 j = 0; j < 6; ++j)
+		{
+			mapPoint.m_neighbour[j] = fmappt->m_neighbours[j];
+		}
+		mapPoint.m_neighbourCount = fmappt->m_neighbour_count;
+		m_mapPoints.push_back(mapPoint);
+	}
+
+	for (u32 i = 0; i < header->m_trigger_point_count; ++i)
+	{
+		ppd_trigger_point_t* triggerpt = (ppd_trigger_point_t*)(buffer + header->m_trigger_point_offset) + i;
+		triggerPoint.m_id = triggerpt->m_trigger_id;
+		triggerPoint.m_action = token_to_string(triggerpt->m_trigger_action);
+		triggerPoint.m_range = triggerpt->m_trigger_range;
+		triggerPoint.m_reset_delay = triggerpt->m_trigger_reset_delay;
+		triggerPoint.m_reset_dist = triggerpt->m_trigger_reset_dist;
+		triggerPoint.m_flags = triggerpt->m_flags;
+		triggerPoint.m_position = triggerpt->m_position;
+		triggerPoint.m_neighbours[0] = triggerpt->m_neighbours[0];
+		triggerPoint.m_neighbours[1] = triggerpt->m_neighbours[1];
+		m_triggerPoints.push_back(triggerPoint);
+	}
+
+	for (u32 i = 0; i < header->m_intersection_count; ++i)
+	{
+		ppd_intersection_t* is = (ppd_intersection_t*)(buffer + header->m_intersection_offset) + i;
+		intersection.m_curveId = is->m_inter_curve_id;
+		intersection.m_position = is->m_inter_position;
+		intersection.m_radius = is->m_inter_radius;
+		intersection.m_flags = is->m_flags;
+		m_intersections.push_back(intersection);
 	}
 
 	m_loaded = true;

--- a/src/prefab/prefab.h
+++ b/src/prefab/prefab.h
@@ -50,6 +50,7 @@ private:
 	bool loadVersion0x16(const uint8_t *const buffer, const size_t size);
 	bool loadVersion0x17(const uint8_t *const buffer, const size_t size);
 	bool loadVersion0x18(const uint8_t *const buffer, const size_t size);
+	bool loadVersion0x19(const uint8_t *const buffer, const size_t size);
 
 private:
 	Array<Node> m_nodes;

--- a/src/structs/ppd_0x19.h
+++ b/src/structs/ppd_0x19.h
@@ -1,0 +1,173 @@
+/******************************************************************************
+ *
+ *  Project:	ConverterPIX @ Core
+ *  File:		/structs/ppd_0x19.h
+ *
+ *		  _____                          _            _____ _______   __
+ *		 / ____|                        | |          |  __ \_   _\ \ / /
+ *		| |     ___  _ ____   _____ _ __| |_ ___ _ __| |__) || |  \ V /
+ *		| |    / _ \| '_ \ \ / / _ \ '__| __/ _ \ '__|  ___/ | |   > <
+ *		| |___| (_) | | | \ V /  __/ |  | ||  __/ |  | |    _| |_ / . \
+ *		 \_____\___/|_| |_|\_/ \___|_|   \__\___|_|  |_|   |_____/_/ \_\
+ *
+ *
+ *  Copyright (C) 2025 Michal Wojtowicz.
+ *  All rights reserved.
+ *
+ *   This software is ditributed WITHOUT ANY WARRANTY; without even
+ *   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *   PURPOSE. See the copyright file for more information.
+ *
+ *****************************************************************************/
+
+#pragma once
+
+#include <math/vector.h>
+#include <math/matrix.h>
+#include <math/quaternion.h>
+#include <utils/token.h>
+
+#pragma pack(push, 1)
+
+namespace prism
+{
+	namespace ppd_0x19
+	{
+		struct ppd_node_t // sizeof(104)
+		{
+			u32 m_terrain_point_idx;
+			u32 m_terrain_point_count;
+			u32 m_variant_idx;
+			u32 m_variant_count;
+			float3 m_pos;
+			float3 m_dir;
+			i32 m_input_lines[8];
+			i32 m_output_lines[8];
+		};	ENSURE_SIZE(ppd_node_t, 104);
+
+		struct ppd_curve_t // sizeof(132)
+		{
+			token_t m_name;
+			u32 m_flags;
+			u32 m_leads_to_nodes;
+			float3 m_start_pos;
+			float3 m_end_pos;
+			quat_t m_start_rot;
+			quat_t m_end_rot;
+			float m_length;
+			i32 m_next_lines[4];
+			i32 m_prev_lines[4];
+			u32 m_count_next;
+			u32 m_count_prev;
+			i32 m_semaphore_id;
+			token_t m_traffic_rule;
+			u32 m_newdata1_id;
+		};	ENSURE_SIZE(ppd_curve_t, 132);
+
+		struct ppd_sign_t // sizeof(52)
+		{
+			token_t m_name;
+			float3 m_position;
+			quat_t m_rotation;
+			token_t m_model;
+			token_t m_part;
+		};	ENSURE_SIZE(ppd_sign_t, 52);
+
+		struct ppd_semaphore_t // sizeof(84)
+		{
+			float3 m_position;
+			quat_t m_rotation;
+			u32 m_type;
+			u32 m_semaphore_id;
+			float4 m_intervals;
+			float m_cycle;
+			token_t m_profile;
+			u32 m_unknown;
+			u32 m_unknown2[4];
+		};	ENSURE_SIZE(ppd_semaphore_t, 84);
+
+		struct ppd_spawn_point_t // sizeof(32)
+		{
+			float3 m_position;
+			quat_t m_rotation;
+			u32 m_type;
+			u32 m_flags;
+		};	ENSURE_SIZE(ppd_spawn_point_t, 36);
+
+		struct ppd_map_point_t // sizeof(48)
+		{
+			u32 m_map_visual_flags;
+			u32 m_map_nav_flags;
+			float3 m_position;
+			i32 m_neighbours[6];
+			u32 m_neighbour_count;
+		};	ENSURE_SIZE(ppd_map_point_t, 48);
+
+		struct ppd_terrain_point_variant_t
+		{
+			u32 m_attach0;
+			u32 m_attach1;
+		};	ENSURE_SIZE(ppd_terrain_point_variant_t, 8);
+
+		struct ppd_trigger_point_t // sizeof(48)
+		{
+			u32 m_trigger_id;
+			token_t m_trigger_action;
+			float m_trigger_range;
+			float m_trigger_reset_delay;
+			float m_trigger_reset_dist;
+			u32 m_flags;
+			float3 m_position;
+			s32 m_neighbours[2];
+		};	ENSURE_SIZE(ppd_trigger_point_t, 48);
+
+		struct ppd_intersection_t // sizeof(16)
+		{
+			u32 m_inter_curve_id;
+			float m_inter_position;
+			float m_inter_radius;
+			u32 m_flags;
+		};	ENSURE_SIZE(ppd_intersection_t, 16);
+
+		struct ppd_newdata1_t // sizeof(188)
+		{
+			u32 m_data[47];
+		};	ENSURE_SIZE(ppd_newdata1_t, 188);
+
+		struct ppd_header_t
+		{
+			u32 m_version;                      // +0
+
+			u32 m_node_count;                   // +4
+			u32 m_nav_curve_count;              // +8
+			u32 m_sign_count;                   // +12
+			u32 m_semaphore_count;              // +16
+			u32 m_spawn_point_count;            // +20
+			u32 m_terrain_point_count;          // +24
+			u32 m_terrain_point_variant_count;  // +28
+			u32 m_map_point_count;              // +32
+			u32 m_trigger_point_count;          // +36
+			u32 m_intersection_count;           // +40
+			u32 m_newdata1_count;               // +44
+
+			u32 m_node_offset;                  // +48
+			u32 m_nav_curve_offset;             // +52
+			u32 m_sign_offset;                  // +56
+			u32 m_semaphore_offset;             // +60
+			u32 m_spawn_point_offset;           // +64
+			u32 m_terrain_point_pos_offset;     // +68
+			u32 m_terrain_point_normal_offset;  // +72
+			u32 m_terrain_point_variant_offset; // +76
+			u32 m_map_point_offset;             // +80
+			u32 m_trigger_point_offset;         // +84
+			u32 m_intersection_offset;          // +88
+			u32 m_newdata1_offset;              // +92
+
+			static const u32 SUPPORTED_VERSION = 0x19;
+		};	ENSURE_SIZE(ppd_header_t, 96);
+	} // namespace ppd_0x18
+} // namespace prism
+
+#pragma pack(pop)
+
+/* eof */


### PR DESCRIPTION
This pull request adds support for new PPD (0x19) format from 1.55: Unknown empty data was added in ppd_semaphore_t. For now everywhere it's 0x00 so I can't check what this data does.

There is also new attribute - "lod_switch_distance". Technically it was added in 1.51, but previously in "conversion_tools_2_18" it was not assigned to any aux[] attribute. That attribute is also specific. Value in pre147 format is divided by 25 comparing to post147. I made small fix in material_converter_147.cpp to calculate it, but code should be checked by someone who know C++ better than me.

It is also worth mentioning that with conversion tool 2.20 at least one more attribute was added - "diffuse_secondary". At the moment there is no equivalent in pre147 format and it is hard to say if there ever will be one. For now it cause problems if it's converted as is ("unable to convert attribute diffuse_secondary to new input id."), so it should be removed by hand from .pix files. Maybe it's worth to protect against this in code?
Although for now, I think it's worth waiting for the official release of 1.55, because maybe conversion tool will be updated as well.