### PR TITLE
Fixed dir creation issue on linux

### DIFF
--- a/src/fs/sysfilesystem.cpp
+++ b/src/fs/sysfilesystem.cpp
@@ -118,7 +118,7 @@ bool SysFileSystem::mkdir(const String &dir)
 		return true;
 	}
 	dirr += '/';
-	for( size_t pos = dirr.find( '/', 0 ); pos != -1; pos = dirr.find( '/', pos + 1 ) )
+	for( size_t pos = dirr.find( '/', 1 ); pos != String::npos; pos = dirr.find( '/', pos + 1 ) )
 	{
 		if( !dirExistsStatic( dirr.substr( 0, pos ).c_str() ) )
 		{


### PR DESCRIPTION
An absolute file/dir path on linux starts with '/' so having dirr.find( '/', 0 ) results with pos=0 in the first iteration, dirr.substr( 0, pos ) returns an empty string, finally mkdir() in the code below tries to create an empty name dir and fails to do so.